### PR TITLE
Handle `spare` fields correctly

### DIFF
--- a/lelei/parser.py
+++ b/lelei/parser.py
@@ -43,6 +43,8 @@ def struct_field_lenght(field_doc, field_ast):
             except ValueError as ve:
                 if field_ast["type"] == "raw(*)":
                     lenght_ast["bits"] = 8
+                elif field_ast["type"] == "spare":
+                    lenght_ast["bits"] = 8
                 else:
                     raise ve
     return lenght_ast

--- a/tests/test_basic_types.py
+++ b/tests/test_basic_types.py
@@ -23,6 +23,10 @@ class TestSpareType(unittest.TestCase):
         spare_desc = ET.fromstring('<field type="spare" bits="a">woot</field>')
         self.assertRaises(ValueError, lambda : structureparser.parse_field(spare_desc))
 
+    def test_spare_nosize(self):
+        spare_desc = ET.fromstring('<field type="spare"></field>')
+        result = structureparser.parse_field(spare_desc)
+
 class TestFloat(unittest.TestCase):
     
     def test_float32(self):

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -39,6 +39,21 @@ class TestFieldBuilder(unittest.TestCase):
     #     res = ws.build_field(parsed_doc)
     #     self.assertEqual("uint8{ns=0} test;", res)
 
+    def test_spare_size_ignored_bits(self):
+        parsed_doc = parser.parse_field(ET.fromstring('<field type="spare" bits="10">test</field>'))
+        res = ws.build_field(parsed_doc)
+        self.assertEqual("spare test;", res)
+
+    def test_spare_size_ignored_lenght(self):
+        parsed_doc = parser.parse_field(ET.fromstring('<field type="spare" lenght="10">test</field>'))
+        res = ws.build_field(parsed_doc)
+        self.assertEqual("spare test;", res)
+
+    def test_spare_nosize(self):
+        parsed_doc = parser.parse_field(ET.fromstring('<field type="spare">test</field>'))
+        res = ws.build_field(parsed_doc)
+        self.assertEqual("spare test;", res)
+
 class TestStructBuilder(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
a `spare` field is just 1 byte long.
if defined, size (bits/lenght) is ignored.

Fixes #5
